### PR TITLE
Fix for Cordova

### DIFF
--- a/timesync-client.js
+++ b/timesync-client.js
@@ -31,9 +31,18 @@ var attempts = 0;
   we should try taking multiple measurements.
  */
 var updateOffset = function() {
-  var t0;
+  var t0,
+    url = "/_timesync",
+    root = __meteor_runtime_config__.ROOT_URL;
+  // Use absolute URL in Cordova
+  if (Meteor.isCordova) {
+    if (root[root.length - 1] === '/' ) {
+      root = root.substring(0, root.length - 1);
+    }
+    url = root + url;
+  }
   t0 = Date.now();
-  HTTP.get("/_timesync", function(err, response) {
+  HTTP.get(url, function(err, response) {
     var t3 = Date.now(); // Grab this now
     if (err) {
       //  We'll still use our last computed offset if is defined

--- a/timesync-server.js
+++ b/timesync-server.js
@@ -12,6 +12,11 @@ WebApp.rawConnectHandlers.use("/_timesync",
     // Avoid MIME type warnings in browsers
     res.setHeader("Content-Type", "text/plain");
 
+    // Cordova lives in meteor.local, so it does CORS
+    if (req.headers && req.headers.origin === 'http://meteor.local') {
+      res.setHeader('Access-Control-Allow-Origin', 'http://meteor.local');
+    }
+
     res.end(Date.now().toString());
   }
 );


### PR DESCRIPTION
Since the Cordova meteor app is served under `http://meteor.local`, we need to use absolute URLs when calling the server and allow CORS.

Otherwise, requests are sent to the local URL (which is not found) and sync fails.