### PR TITLE
Cordova support

### DIFF
--- a/timesync-client.js
+++ b/timesync-client.js
@@ -45,7 +45,15 @@ var attempts = 0;
 var updateOffset = function() {
   var t0;
   t0 = Date.now();
-  HTTP.get("/_timesync", function(err, response) {
+
+  // Cordova apps need special treatment, because the phone will
+  // have a local server and we need it to connect to the remote
+  // server. Luckily ROOT_URL points to the corrent place.
+  var rootUrl = ''
+  if (Meteor.isCordova)
+    rootUrl = __meteor_runtime_config__.ROOT_URL
+
+  HTTP.get(rootUrl + "/_timesync", function(err, response) {
     var t3 = Date.now(); // Grab this now
     if (err) {
       //  We'll still use our last computed offset if is defined

--- a/timesync-server.js
+++ b/timesync-server.js
@@ -8,6 +8,7 @@ WebApp.rawConnectHandlers.use("/_timesync",
     res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
     res.setHeader("Pragma", "no-cache");
     res.setHeader("Expires", 0);
+    res.setHeader("Access-Control-Allow-Origin", "*");
 
     // Avoid MIME type warnings in browsers
     res.setHeader("Content-Type", "text/plain");


### PR DESCRIPTION
Turns out a Cordova app will try to connect to the phones route instead of the server route.

The ROOT_URL line can be added straight into `HTTP.get()` like so:

    HTTP.get(__meteor_runtime_config__.ROOT_URL + "/_timesync", function(err, response) {})

because it works (tested) on both browsers and Cordova apps, but I added Meteor.isCordova just to be sure it's compatible with everyones apps.