### PR TITLE
Adding CORS compatibility for Meteor 1.3

### DIFF
--- a/timesync-server.js
+++ b/timesync-server.js
@@ -12,9 +12,11 @@ WebApp.rawConnectHandlers.use("/_timesync",
     // Avoid MIME type warnings in browsers
     res.setHeader("Content-Type", "text/plain");
 
-    // Cordova lives in meteor.local, so it does CORS
-    if (req.headers && req.headers.origin === 'http://meteor.local') {
-      res.setHeader('Access-Control-Allow-Origin', 'http://meteor.local');
+    // Cordova lives in a local webserver, so it does CORS, we need to bless it's requests in order for it to accept
+    // our results
+    var cordovaClientOriginRegex = /^http:\/\/localhost:1[23]\d\d\d$/;
+    if (req.headers && req.headers.origin && (cordovaClientOriginRegex.test(req.headers.origin) || req.headers.origin === 'http://meteor.local')) {
+      res.setHeader('Access-Control-Allow-Origin', req.headers.origin);
     }
 
     res.end(Date.now().toString());


### PR DESCRIPTION
Hi, I think this is required to stay compatible with Cordova Devices on Meteor 1.3. It was for me in 1.3 Beta 11 / 12.