### PR TITLE
Support prefixed paths (i.e. other than /) by using rooturl

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "mizzao:timesync",
   summary: "NTP-style time synchronization between server and client",
-  version: "0.3.4",
+  version: "0.3.5",
   git: "https://github.com/mizzao/meteor-timesync.git"
 });
 

--- a/timesync-client.js
+++ b/timesync-client.js
@@ -46,9 +46,10 @@ var attempts = 0;
 // Only use Meteor.absoluteUrl for Cordova; see
 // https://github.com/meteor/meteor/issues/4696
 // https://github.com/mizzao/meteor-timesync/issues/30
-var syncUrl = "/_timesync";
+var _basePath = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX || '';
+var syncUrl = _basePath + "/_timesync";
 if (Meteor.isCordova) {
-  syncUrl = Meteor.absoluteUrl("_timesync");
+  syncUrl = Meteor.absoluteUrl(_basePath + "_timesync");
 }
 
 var updateOffset = function() {


### PR DESCRIPTION
Allows rooturl to be changed to have a path prefix (i.e. other than / - for example, <domain>/blah).

Should address #36