### PR TITLE
guess new server offset

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,7 @@
 ## vNEXT
 
+- guess new offset instead of unsetting if the client time has changed. This prevents that `TimeSync.serverTime` returns `undefined` after the time has changed and the client isn't in sync with the server.
+
 ## v0.4.0
 
 - Update CORS headers to support Meteor 1.3. (#37, #41)

--- a/tests/client.js
+++ b/tests/client.js
@@ -2,35 +2,32 @@ Tinytest.add("timesync - tick check - normal tick", function(test) {
   var lastTime = 5000;
   var currentTime = 6000;
   var interval = 1000;
-  var tolerance = 1000;
 
-  test.equal(SyncInternals.timeCheck(lastTime, currentTime, interval, tolerance), true);
+  test.equal(SyncInternals.getDiscrepancy(lastTime, currentTime, interval), 0);
 });
 
 Tinytest.add("timesync - tick check - slightly off", function(test) {
   var lastTime = 5000;
   var currentTime = 6500;
   var interval = 1000;
-  var tolerance = 1000;
 
-  test.equal(SyncInternals.timeCheck(lastTime, currentTime, interval, tolerance), true);
+  test.equal(SyncInternals.getDiscrepancy(lastTime, currentTime, interval), 500);
 
   currentTime = 5500;
 
-  test.equal(SyncInternals.timeCheck(lastTime, currentTime, interval, tolerance), true);
+  test.equal(SyncInternals.getDiscrepancy(lastTime, currentTime, interval), -500);
 });
 
 Tinytest.add("timesync - tick check - big jump", function(test) {
   var lastTime = 5000;
   var currentTime = 0;
   var interval = 1000;
-  var tolerance = 1000;
 
-  test.equal(SyncInternals.timeCheck(lastTime, currentTime, interval, tolerance), false);
+  test.equal(SyncInternals.getDiscrepancy(lastTime, currentTime, interval), -6000);
 
   currentTime = 10000;
 
-  test.equal(SyncInternals.timeCheck(lastTime, currentTime, interval, tolerance), false);
+  test.equal(SyncInternals.getDiscrepancy(lastTime, currentTime, interval), 4000);
 });
 
 /*

--- a/tests/client.js
+++ b/tests/client.js
@@ -93,7 +93,7 @@ Tinytest.addAsync("timesync - basic - different sync intervals", function(test, 
     cCount++;
   });
 
-  var testInterval = 5000;
+  var testInterval = 4990;
 
   Meteor.setTimeout(function() {
 

--- a/timesync-client.js
+++ b/timesync-client.js
@@ -18,6 +18,8 @@ SyncInternals = {
   offset: undefined,
   roundTripTime: undefined,
   offsetDep: new Deps.Dependency(),
+  syncDep: new Deps.Dependency(),
+  isSynced: false,
   timeTick: {},
   getDiscrepancy: function (lastTime, currentTime, interval) {
     return currentTime - (lastTime + interval)
@@ -70,6 +72,7 @@ var updateOffset = function() {
     attempts = 0; // It worked
 
     var ts = parseInt(response.content);
+    SyncInternals.isSynced = true;
     SyncInternals.offset = Math.round(((ts - t0) + (ts - t3)) / 2);
     SyncInternals.roundTripTime = t3 - t0; // - (ts - ts) which is 0
     SyncInternals.offsetDep.changed();
@@ -79,12 +82,10 @@ var updateOffset = function() {
 // Reactive variable for server time that updates every second.
 TimeSync.serverTime = function(clientTime, interval) {
   check(interval, Match.Optional(Match.Integer));
-  // If we don't know the offset, we can't provide the server time.
-  if ( !TimeSync.isSynced() ) return undefined;
   // If a client time is provided, we don't need to depend on the tick.
   if ( !clientTime ) getTickDependency(interval || defaultInterval).depend();
 
-  // SyncInternals.offsetDep.depend(); implicit as we call isSynced()
+  SyncInternals.offsetDep.depend(); // depend on offset to enable reactivity
   // Convert Date argument to epoch as necessary
   return (+clientTime || Date.now()) + SyncInternals.offset;
 };
@@ -102,7 +103,7 @@ TimeSync.roundTripTime = function() {
 
 TimeSync.isSynced = function() {
   SyncInternals.offsetDep.depend();
-  return SyncInternals.offset !== undefined;
+  return SyncInternals.isSynced;
 };
 
 var resyncIntervalId = null;
@@ -161,6 +162,7 @@ Meteor.setInterval(function() {
     log("Clock discrepancy detected. Attempting re-sync.");
     // Refuse to compute server time and try to guess new server offset. Guessing only works if the server time hasn't changed.
     SyncInternals.offset = SyncInternals.offset - discrepancy;
+    SyncInternals.isSynced = false;
     SyncInternals.offsetDep.changed();
     TimeSync.resync();
   }

--- a/timesync-client.js
+++ b/timesync-client.js
@@ -152,7 +152,7 @@ Meteor.setInterval(function() {
   var currentClientTime = Date.now();
 
   var discrepancy = SyncInternals.getDiscrepancy(lastClientTime, currentClientTime, defaultInterval);
-  if (discrepancy < tickCheckTolerance) {
+  if (Math.abs(discrepancy) < tickCheckTolerance) {
     // No problem here, just keep ticking along
     SyncInternals.timeTick[defaultInterval].changed();
   } else {


### PR DESCRIPTION
If the client time has changed, but the server is unreachable, `serverTime` is undefined. Normally this case occurs if the computer wake up from hibernation and have no network connection.
This change tries to guess the new offset.
Guessing the offset only works if the server time hasn't changed (I think, in the most cases it’s UTC and it doesn’t change).