### PR TITLE
Fixed TimeSync returning NaN in meteor-desktop clients

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 ## vNEXT
 
+## v0.5.1
+
+- Fix an issue where `TimeSync.ServerTime` returned NaN when executed in meteor-desktop.
+
 ## v0.5.0
 
 - guess new offset instead of unsetting if the client time has changed. This prevents that `TimeSync.serverTime` returns `undefined` after the time has changed and the client isn't in sync with the server.

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "mizzao:timesync",
   summary: "NTP-style time synchronization between server and client",
-  version: "0.5.0",
+  version: "0.5.1",
   git: "https://github.com/mizzao/meteor-timesync.git"
 });
 

--- a/timesync-client.js
+++ b/timesync-client.js
@@ -40,8 +40,8 @@ var attempts = 0;
  */
 
 var syncUrl;
-if (Meteor.isCordova) {
-  // Only use Meteor.absoluteUrl for Cordova; see
+if (Meteor.isCordova || Meteor.isDesktop) {
+  // Only use Meteor.absoluteUrl for Cordova and Desktop; see
   // https://github.com/meteor/meteor/issues/4696
   // https://github.com/mizzao/meteor-timesync/issues/30
   // Cordova should never be running out of a subdirectory...

--- a/timesync-server.js
+++ b/timesync-server.js
@@ -18,7 +18,8 @@ WebApp.rawConnectHandlers.use("/_timesync",
     // and http://meteor.local for earlier versions
     const origin = req.headers.origin;
 
-    if (origin && ( origin === 'http://meteor.local' ||
+    if (origin && ( origin === 'http://meteor.local' || 
+        origin === 'meteor://desktop' || 
         /^http:\/\/localhost:1[23]\d\d\d$/.test(origin) ) ) {
       res.setHeader('Access-Control-Allow-Origin', origin);
     }


### PR DESCRIPTION
I'm working on a meteor-desktop app for work and ran into an issue where the TimeSync was returning NaN. This pull request fixes it, allowing TimeSync to work correctly in meteor-desktop clients.